### PR TITLE
Remove nodejs-legacy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && apt install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt update && apt install -yq \
-    nodejs npm nodejs-legacy
+    nodejs npm
 
 RUN npm install -g @mapbox/spritezero-cli
 


### PR DESCRIPTION
There is no nodejs-legacy package in ubuntu bionic.

After making this change, building the container and running it worked fine.